### PR TITLE
Correcting error in kubeadm join syntax

### DIFF
--- a/docs/reference/setup-tools/kubeadm/kubeadm-join.md
+++ b/docs/reference/setup-tools/kubeadm/kubeadm-join.md
@@ -83,7 +83,7 @@ using one of the other modes if possible.
 **Example `kubeadm join` command:**
 
 ```
-kubeadm join --discovery-token abcdef.1234567890abcdef --discovery-token-unsafe-skip-ca-verification 1.2.3.4:6443`
+kubeadm join --token abcdef.1234567890abcdef --discovery-token-unsafe-skip-ca-verification 1.2.3.4:6443`
 ```
 
 **Advantages:**


### PR DESCRIPTION
On k8s 1.9, using --discovery-token 
kubeadm join --discovery-token abcdef.1234567890abcdef --discovery-token-unsafe-skip-ca-verification 1.2.3.4:6443`
returns  an error, but the node joins successfully with 
kubeadm join --token abcdef.1234567890abcdef --discovery-token-unsafe-skip-ca-verification 1.2.3.4:6443`

> NOTE: After opening the PR, please *un-check and re-check* the ["Allow edits from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) box so that maintainers can work on your patch and speed up the review process. This is a temporary workaround to address a known issue with GitHub.> 
>
> Please delete this note before submitting the pull request.

![Allow edits from maintainers checkbox](https://help.github.com/assets/images/help/pull_requests/allow-maintainers-to-make-edits-sidebar-checkbox.png)
